### PR TITLE
Calculate canonical NLG metrics & eliminate legacy args hardcoding

### DIFF
--- a/src/main/java/org/aigents/nlp/gen/Generator.java
+++ b/src/main/java/org/aigents/nlp/gen/Generator.java
@@ -47,7 +47,6 @@ public class Generator {
 	public static boolean tooMuch = false;
 
 	public static void main(String[] args) throws IOException {
-		args = new String[] {"en/4.0.dict", "gutenberg544.txt"};
 		long startTime = System.currentTimeMillis();
 		if (args.length == 2) {
 			int single = 0;

--- a/src/main/java/org/aigents/nlp/gen/SegmentWithExceptions.java
+++ b/src/main/java/org/aigents/nlp/gen/SegmentWithExceptions.java
@@ -41,7 +41,6 @@ public class SegmentWithExceptions {
 	public static Dictionary dict, hyphenated;
 
 	public static void main(String[] args) throws IOException {
-		args = new String[] {"en/4.0.dict", "gutenberg544.txt"};
 		if (args.length > 2) {
 			try {
 				if (args[0].contains("/4.0.dict")) {

--- a/src/main/java/org/aigents/nlp/gen/SmallGrammarGen.java
+++ b/src/main/java/org/aigents/nlp/gen/SmallGrammarGen.java
@@ -46,7 +46,6 @@ public class SmallGrammarGen {
 	public static Dictionary dict, hyphenated;
 
 	public static void main(String[] args) throws IOException {
-		args = new String[] {"dict_30C_2018-12-31_0006.4.0.dict", "poc_english.txt"};
 		long startTime = System.currentTimeMillis();
 		if (args.length == 2) {
 			int single = 0;

--- a/src/test/resources/metrics.py
+++ b/src/test/resources/metrics.py
@@ -1,0 +1,134 @@
+fname = "results.txt"
+
+# BLEU
+from nltk.translate.bleu_score import sentence_bleu, corpus_bleu
+scores = []
+f = open("poc_english.txt", "r")
+f2 = open(fname, "r")
+lines = f.readlines()
+cand = f2.readlines()
+for i in range(len(cand)):
+    line = lines[i]
+    candidate = []
+    l = cand[i].lower().strip('\n')[1:len(cand[i])-2].split(", ")
+    for item in l:
+        item = item.strip('.').split(" ")
+        candidate.append(item)
+    arr = line.strip('.\n').split(" ")
+    for i in range(len(arr)):
+        arr[i] = arr[i].lower()
+    reference = [arr]
+    for c in candidate:
+        # print(reference, c, ': ', sentence_bleu(reference, c, weights=(1,0)))
+        scores.append(sentence_bleu(reference, c, weights=(1,0)))
+
+print("BLEU: " + str(sum(scores)/(1.0*len(scores))))
+
+# Word2Vec Cosine Similarity
+import torch
+import torch.nn.functional as F
+from sentence_transformers import SentenceTransformer
+import nltk
+from nltk import tokenize
+def similarity(par1, par2):
+    transformer = SentenceTransformer('roberta-base-nli-stsb-mean-tokens')
+    transformer.eval()
+    par1 = tokenize.sent_tokenize(par1)
+    vec1 = torch.Tensor(transformer.encode(par1))
+    vec1 = vec1.mean(0)
+    par2 = tokenize.sent_tokenize(par2)
+    vec2 = torch.Tensor(transformer.encode(par2))
+    vec2 = vec2.mean(0)
+    cos_sim = F.cosine_similarity(vec1, vec2, dim=0)
+    return cos_sim.item()
+
+scores = []
+f = open("poc_english.txt", "r")
+f2 = open(fname, "r")
+lines = f.readlines()
+cand = f2.readlines()
+for i in range(len(cand)):
+    line = lines[i]
+    candidate = []
+    l = cand[i].lower().strip('\n')[1:len(cand[i])-2].split(", ")
+    for item in l:
+        item = item.strip('.').split(" ")
+        candidate.append(item)
+    arr = line.strip('.\n').split(" ")
+    if (len(arr) == 1):
+        continue
+    for i in range(len(arr)):
+        arr[i] = arr[i].lower()
+    reference = arr
+    for c in candidate:
+        scores.append(similarity(" ".join(reference), " ".join(c)))
+print("Word2Vec Cosine Similarity: " + str(sum(scores)/(1.0*len(scores))))
+
+# WER
+import numpy as np
+def wer_score(hyp, ref, print_matrix=False):
+  N = len(hyp)
+  M = len(ref)
+  L = np.zeros((N,M))
+  for i in range(0, N):
+    for j in range(0, M):
+      if min(i,j) == 0:
+        L[i,j] = max(i,j)
+      else:
+        deletion = L[i-1,j] + 1
+        insertion = L[i,j-1] + 1
+        sub = 1 if hyp[i] != ref[j] else 0
+        substitution = L[i-1,j-1] + sub
+        L[i,j] = min(deletion, min(insertion, substitution))
+        # print("{} - {}: del {} ins {} sub {} s {}".format(hyp[i], ref[j], deletion, insertion, substitution, sub))
+  if print_matrix:
+    print("WER matrix ({}x{}): ".format(N, M))
+    print(L)
+  return int(L[N-1, M-1])
+
+scores = []
+f = open("poc_english.txt", "r")
+f2 = open(fname, "r")
+lines = f.readlines()
+cand = f2.readlines()
+for i in range(len(cand)):
+    line = lines[i]
+    candidate = []
+    l = cand[i].lower().strip('\n')[1:len(cand[i])-2].split(", ")
+    for item in l:
+        item = item.strip('.').split(" ")
+        candidate.append(item)
+    arr = line.strip('.\n').split(" ")
+    if (len(arr) == 1):
+        continue
+    for i in range(len(arr)):
+        arr[i] = arr[i].lower()
+    reference = arr
+    for c in candidate:
+        scores.append(wer_score(c, reference))
+print("WER: " + str(sum(scores)/(1.0*len(scores))))
+
+# TER
+import pyter
+
+scores = []
+f = open("poc_english.txt", "r")
+f2 = open(fname, "r")
+lines = f.readlines()
+cand = f2.readlines()
+for i in range(len(cand)):
+    line = lines[i]
+    candidate = []
+    l = cand[i].lower().strip('\n')[1:len(cand[i])-2].split(", ")
+    for item in l:
+        item = item.strip('.').split(" ")
+        candidate.append(item)
+    arr = line.strip('.\n').split(" ")
+    if (len(arr) == 1):
+        continue
+    for i in range(len(arr)):
+        arr[i] = arr[i].lower()
+    reference = arr
+    for c in candidate:
+        scores.append(pyter.ter(reference, c))
+print("TER: " + str(sum(scores)/(1.0*len(scores))))


### PR DESCRIPTION
Record average BLEU (bigram), Word2Vec Cosine Similarity, WER, and TER:
|                        | `poc_english.txt` using "small world" grammar | `poc_english.txt` using complete LG | `gutenberg544.txt` |
| ------------- | ------------- | ------------- | ------------- |
| Avg. BLEU (Bigram)  | 1.000  | 0.999  | 0.652  |
| Avg. Word2Vec Cosine Similarity  | 0.988  | 0.900  | 0.746  |
| Avg. WER  | 0.246  | 3.713  | 5.976  |
| Avg. TER  | 0.082  | 0.395  | 1.738  |

Eliminate legacy `args` hardcoding (used for testing `Segment`).

Relevant files: [gutenberg.txt](https://github.com/aigents/aigents-java-nlp/files/6260666/gut.txt), [gen.txt](https://github.com/aigents/aigents-java-nlp/files/6260668/gen.txt), [smallgrammargen.txt](https://github.com/aigents/aigents-java-nlp/files/6260669/smallgrammargen.txt), [process_py.txt](https://github.com/aigents/aigents-java-nlp/files/6260691/process_py.txt)